### PR TITLE
[FEAT] : 시즌별 상품 조회 페이지 구현 #137

### DIFF
--- a/src/actions/main/season.ts
+++ b/src/actions/main/season.ts
@@ -12,9 +12,11 @@ export const getSeasonMedia = async (): Promise<SeasonMediaType[]> => {
   return data.data;
 };
 
-export const getSeasonMediaById = async (id: string): Promise<any> => {
-  const data = await fetchData<commonResType<any>>(
-    `/api/v1/season/${id}`,
+export const getSeasonMediaById = async (
+  id: number,
+): Promise<SeasonMediaType> => {
+  const data = await fetchData<commonResType<SeasonMediaType>>(
+    `/api/v1/season-media-list/${id + 22}`,
     "GET",
     "",
     "force-cache",

--- a/src/actions/product/getSeasonProduct.ts
+++ b/src/actions/product/getSeasonProduct.ts
@@ -1,0 +1,12 @@
+import { commonResType } from "@/types/ResponseType";
+import { fetchData } from "../common/common";
+
+export const getSeasonProduct = async (seasonId: string): Promise<string[]> => {
+  const data = await fetchData<commonResType<string[]>>(
+    `/api/v1/season-product-list/bySeason/${seasonId}`,
+    "GET",
+    "",
+    "force-cache",
+  );
+  return data.data;
+};

--- a/src/app/(main)/@modal/(.)event/[id]/page.tsx
+++ b/src/app/(main)/@modal/(.)event/[id]/page.tsx
@@ -5,6 +5,7 @@ import { SeasonMediaType } from "@/types/main/CarouselDataType";
 import EventModal from "./modal";
 export default async function Page({ params }: { params: { id: string } }) {
   const carouselData: SeasonMediaType[] = await getSeasonMedia();
+  console.log("캐러셀 데이터 뭐찍히나요? ", carouselData);
   return (
     <EventModal>
       <main className="w-full">

--- a/src/app/(main)/season/[seasonId]/page.tsx
+++ b/src/app/(main)/season/[seasonId]/page.tsx
@@ -1,0 +1,37 @@
+import { getItemCardInfo } from "@/actions/getItemCardInfo";
+import { getSeasonMediaById } from "@/actions/main/season";
+import { getSeasonProduct } from "@/actions/product/getSeasonProduct";
+import ItemCard from "@/components/Items/ItemCard";
+import Image from "next/image";
+export default async function page({
+  params,
+}: {
+  params: { seasonId: string };
+}) {
+  const seasonMedia = await getSeasonMediaById(Number(params.seasonId));
+  const seasonProductList = await getSeasonProduct(params.seasonId);
+  const resultCardInfoList = await Promise.all(
+    seasonProductList.map((item) => getItemCardInfo(item)),
+  );
+  return (
+    <>
+      <div className="w-full overflow-hidden mb-4">
+        <Image
+          src={seasonMedia.mediaURL}
+          alt={seasonMedia.imageName}
+          width={2000}
+          height={2000}
+          className="object-cover"
+          priority
+        ></Image>
+      </div>
+      <ul className="grid grid-cols-2 gap-4 px-4">
+        {resultCardInfoList.map((item, index) => (
+          <li>
+            <ItemCard key={index} item={item} authStatus={false} />
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/components/pages/main/MainSeason.tsx
+++ b/src/components/pages/main/MainSeason.tsx
@@ -7,12 +7,12 @@ export default async function MainSeason({
   SeasonData: SeasonMediaType[];
 }) {
   return (
-    <section className="flex place-items-baseline gap-2 w-[100%] overflow-x-auto scroll-item whitespace-nowrap">
+    <ul className="flex place-items-baseline gap-2 w-[100%] overflow-x-auto scroll-item whitespace-nowrap">
       {SeasonData.filter(
         (item) => item.mediaType === "running-season-thumbsImg",
       ).map((item) => (
         <SeasonCard key={item.id} item={item} />
       ))}
-    </section>
+    </ul>
   );
 }

--- a/src/components/pages/modal/CarouselModal.tsx
+++ b/src/components/pages/modal/CarouselModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { SeasonMediaType } from "@/types/main/CarouselDataType";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 
 export default function CarouselModal({
@@ -11,6 +12,7 @@ export default function CarouselModal({
   id: string;
 }) {
   const imageRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const router = useRouter();
   useEffect(() => {
     if (carouselData.length > 0 && id) {
       const timer = setTimeout(() => {
@@ -26,12 +28,13 @@ export default function CarouselModal({
       return () => clearTimeout(timer);
     }
   }, [carouselData, id]);
+
   return (
     <section>
       {carouselData?.map((item: SeasonMediaType, index) => (
         <div
           key={item.id}
-          className="relative w-full aspect-[13/10] "
+          className="relative w-full aspect-[13/10]"
           ref={(el) => {
             if (el) {
               imageRefs.current[index - 1] = el;
@@ -39,6 +42,7 @@ export default function CarouselModal({
           }}
         >
           <Image
+            onClick={() => router.push(`/season/${item.seasonId}`)}
             src={item.mediaURL}
             alt="item"
             fill

--- a/src/components/ui/MainCarousel.tsx
+++ b/src/components/ui/MainCarousel.tsx
@@ -8,6 +8,7 @@ import {
 import { SeasonMediaType } from "@/types/main/CarouselDataType";
 import Autoplay from "embla-carousel-autoplay";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { PlayCarousel } from "../icons/Index";
 import Pause from "../icons/Pause";
@@ -24,7 +25,7 @@ export default function MainCarousel({
     Autoplay({ delay: 2000, stopOnInteraction: false, stopOnMouseEnter: true }),
   );
   const [isPlaying, setIsPlaying] = useState(true);
-
+  const router = useRouter();
   useEffect(() => {
     if (!api) {
       return;
@@ -61,13 +62,15 @@ export default function MainCarousel({
               className="relative w-[100vw] aspect-[13/10]"
               key={item.id}
             >
-              <Image
-                src={item.mediaURL}
-                alt={item.imageName}
-                fill
-                style={{ objectFit: "cover" }}
-                className="p-0 w-full"
-              />
+              <div onClick={() => router.push(`/season/${item.seasonId}`)}>
+                <Image
+                  src={item.mediaURL}
+                  alt={item.imageName}
+                  fill
+                  style={{ objectFit: "cover" }}
+                  className="p-0 w-full"
+                />
+              </div>
             </CarouselItem>
           ))}
         </CarouselContent>

--- a/src/types/main/CarouselDataType.ts
+++ b/src/types/main/CarouselDataType.ts
@@ -9,7 +9,7 @@ export interface SeasonType {
 
 export interface SeasonMediaType {
   id: number;
-  seasonid: string;
+  seasonId: string;
   mediaURL: string;
   imageName: string;
   mediaType: string;


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#issueNum)
-->

## 📌 관련 이슈

- closed: #137 

## ✨ PR 세부 내용

메인페이지 Carousel에서 시즌 클릭시 시즌 페이지로 이동, 
이동 후 시즌 별 아이템 List 조회

## ⌛ 소요 시간
2H